### PR TITLE
initial optimization, a lot more possible, removed storing of unused …

### DIFF
--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -84,7 +84,7 @@ namespace SQLCover
                 Console.WriteLine(message, args);
         }
 
-        public CoverageResult Cover(string command)
+        public CoverageResult Cover(string command, int timeOut =30)
         {
             try
             {
@@ -96,7 +96,7 @@ namespace SQLCover
                 Debug("Executing Command: {0}", command);
                 try
                 {
-                    _database.Execute(command); //todo read messages or rowcounts or something
+                    _database.Execute(command, timeOut); //todo read messages or rowcounts or something
                 }
                 catch (Exception e)
                 {

--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Data.SqlClient;
+using System.Xml;
 
 namespace SQLCover.Gateway
 {
@@ -52,7 +53,49 @@ namespace SQLCover.Gateway
             }
         }
 
-        public void Execute(string command)
+        public virtual DataTable GetTraceRecords(string query)
+        {
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+                conn.ChangeDatabase(_databaseName);
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = query;
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        var ds = new DataTable();
+                        ds.Columns.Add(new DataColumn("xml"));
+                        while (reader.Read())
+                        {
+                            XmlDocument xml = new XmlDocument();
+                            xml.LoadXml(reader[0].ToString());
+                             
+                            var root = xml.SelectNodes("/event").Item(0);
+
+                            var objectId = xml.SelectNodes("/event/data[@name='object_id']").Item(0);
+                            var offset = xml.SelectNodes("/event/data[@name='offset']").Item(0);
+                            var offsetEnd = xml.SelectNodes("/event/data[@name='offset_end']").Item(0);
+
+                            root.RemoveAll();
+                                 
+                            root.AppendChild(objectId);
+                            root.AppendChild(offset);
+                            root.AppendChild(offsetEnd);
+
+                            var row = ds.NewRow();
+                            row["xml"] = root.OuterXml;
+                            ds.Rows.Add(row);
+
+                        }
+
+                        return ds;
+                    }
+                }
+            }
+        }
+
+        public void Execute(string command, int timeOut)
         {
             using (var conn = new SqlConnection(_connectionString))
             {
@@ -61,6 +104,7 @@ namespace SQLCover.Gateway
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = command;
+                    cmd.CommandTimeout = timeOut;
                     cmd.ExecuteNonQuery();
                 }
             }

--- a/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
@@ -25,10 +25,7 @@ WITH (MAX_MEMORY=100 MB,EVENT_RETENTION_MODE=NO_EVENT_LOSS,MAX_DISPATCH_LATENCY=
         private const string DropTraceFormat = @"drop EVENT SESSION [{0}] ON SERVER ";
 
         private const string ReadTraceFormat = @"select
-    object_name,
-    event_data,
-    file_name,
-    file_offset
+    event_data
 FROM sys.fn_xe_file_target_read_file(N'{0}*.xel', N'{0}*.xem', null, null);";
 
         private const string GetLogDir = @"EXEC xp_readerrorlog 0, 1, N'Logging SQL Server messages in file'";
@@ -65,11 +62,11 @@ FROM sys.fn_xe_file_target_read_file(N'{0}*.xel', N'{0}*.xem', null, null);";
 
         public override List<string> ReadTrace()
         {
-            var data = Gateway.GetRecords(string.Format(ReadTraceFormat, FileName));
+            var data = Gateway.GetTraceRecords(string.Format(ReadTraceFormat, FileName));
             var events = new List<string>();
             foreach (DataRow row in data.Rows)
             {
-                events.Add(row.ItemArray[1].ToString());
+                events.Add(row.ItemArray[0].ToString());
             }
 
 

--- a/src/SQLCover/SQLCover/Trace/TraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/TraceController.cs
@@ -25,12 +25,12 @@ namespace SQLCover.Trace
         public abstract void Drop();
 
 
-        protected void RunScript(string query, string error)
+        protected void RunScript(string query, string error, int timeout =30)
         {
             var script = GetScript(query);
             try
             {
-                Gateway.Execute(script);
+                Gateway.Execute(script, timeout);
             }
             catch (Exception ex)
             {

--- a/src/SQLCover/test/SQLCover.IntegrationTests/SQLCover.IntegrationTests.csproj
+++ b/src/SQLCover/test/SQLCover.IntegrationTests/SQLCover.IntegrationTests.csproj
@@ -81,6 +81,9 @@
       <Name>TestLib</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/SQLCover/test/SQLCover.UnitTests/Parsers/StatementParserTests.cs
+++ b/src/SQLCover/test/SQLCover.UnitTests/Parsers/StatementParserTests.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using Microsoft.SqlServer.Dac.Model;
+using System.Threading.Tasks; 
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using NUnit.Framework;
 using SQLCover.Parsers;

--- a/src/SQLCover/test/SQLCover.UnitTests/SQLCover.UnitTests.csproj
+++ b/src/SQLCover/test/SQLCover.UnitTests/SQLCover.UnitTests.csproj
@@ -86,6 +86,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/SQLCover/test/SQLCover.UnitTests/Source/DatabaseSourceGatewayTests.cs
+++ b/src/SQLCover/test/SQLCover.UnitTests/Source/DatabaseSourceGatewayTests.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using Microsoft.SqlServer.Dac.Model;
+using System.Threading.Tasks; 
 using Moq;
 using NUnit.Framework;
 using SQLCover.Gateway;


### PR DESCRIPTION
edited the reading of the trace to only store the data that is needed to calculate the coverage to reduce memory usage, also added an optional timeout variable that defaults to 30. 