### PR TITLE
Correct issue with incorrectly uncovered CTEs and table variable declarations

### DIFF
--- a/src/SQLCover/SQLCover/CoverageResult.cs
+++ b/src/SQLCover/SQLCover/CoverageResult.cs
@@ -52,27 +52,18 @@ namespace SQLCover
 
         private bool Overlaps(Statement statement, CoveredStatement coveredStatement)
         {
+            var coveredOffset = coveredStatement.Offset / 2;
+
+            if (coveredStatement.OffsetEnd == -1)
+            {
+                // Last statement in the batch, so only covered if the 'start' is equal to or less than the statement start
+                return (statement.Offset >= coveredOffset);
+            }
+
             var statementEnd = statement.Offset + statement.Length;
+            var coveredEnd = coveredStatement.OffsetEnd / 2;
 
-            var coveredOffset = coveredStatement.Offset/2;
-            var coveredEnd = (coveredStatement.OffsetEnd == -1 ? statementEnd + coveredOffset : coveredStatement.OffsetEnd)/2;
-
-            
-
-            if (statement.Offset >= coveredOffset && statementEnd <= coveredEnd)
-                return true;
-
-            if (statement.Offset <= coveredOffset && statementEnd >= coveredEnd)
-                return true;
-
-            if (statement.Offset >= coveredOffset && statementEnd <= coveredEnd)
-                return true;
-
-            if (coveredOffset >= statement.Offset && coveredEnd <= statementEnd)
-                return true;
-
-
-            return false;
+            return (statement.Offset >= coveredOffset && statementEnd <= coveredEnd);
         }
 
         public string RawXml()

--- a/src/SQLCover/SQLCover/Parsers/StatementParser.cs
+++ b/src/SQLCover/SQLCover/Parsers/StatementParser.cs
@@ -127,6 +127,9 @@ namespace SQLCover.Parsers
             if (statement is DeclareVariableStatement)
                 return false;
 
+            if (statement is DeclareTableVariableStatement)
+                return false;
+
             return true;
         }
     }


### PR DESCRIPTION
This pull request resolves issues 7 and 8 on the base fork.

After separating out the logic for 'final statement' overlaps, I was able to simplify greatly the rest of the logic in the function to look for a basic overlap - the 'start' of the covering statement must be less than or equal to the 'start' of the tested statement, and the 'end' must be greater or equal to the 'end', and I can't see a need for other tests.

I've rerun our entire test suite and reported test coverage hasn't changed beyond the specific issues being  tested.