### PR TITLE
Fix issue #5 : badge for licence - Apache 2.0 and not MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![forks badge]][forks]
 [![issues badge]][issues]
 
-[licence badge]:https://img.shields.io/badge/License-Apache%202.0.svg
+[licence badge]:https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [stars badge]:https://img.shields.io/github/stars/GoEddie/SQLCover.svg
 [forks badge]:https://img.shields.io/github/forks/GoEddie/SQLCover.svg
 [issues badge]:https://img.shields.io/github/issues/GoEddie/SQLCover.svg

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![forks badge]][forks]
 [![issues badge]][issues]
 
-[licence badge]:https://img.shields.io/badge/license-MIT-blue.svg
+[licence badge]:https://img.shields.io/badge/License-Apache%202.0.svg
 [stars badge]:https://img.shields.io/github/stars/GoEddie/SQLCover.svg
 [forks badge]:https://img.shields.io/github/forks/GoEddie/SQLCover.svg
 [issues badge]:https://img.shields.io/github/issues/GoEddie/SQLCover.svg


### PR DESCRIPTION
Fixes #5 .

Changes proposed in this pull request:
 - change badge for licence (apache 2.0 in place of MIT)
