### PR TITLE
Remove check on ddl triggers

### DIFF
--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -43,7 +43,7 @@ public IEnumerable<Batch> GetBatches(List<string> objectFilter)
         {
             var table =
                 _databaseGateway.GetRecords(
-                    "select object_id, \'[\' + object_schema_name(object_id) + \'].[\' + object_name(object_id) + \']\' as object_name, definition, uses_quoted_identifier from sys.sql_modules where object_id not in (select object_id from sys.objects where type = 'IF')");
+                    "select object_id, \'[\' + object_schema_name(object_id) + \'].[\' + object_name(object_id) + \']\' as object_name, definition, uses_quoted_identifier from sys.sql_modules where object_id not in (select object_id from sys.objects where type = 'IF') AND object_schema_name(object_id) IS NOT NULL AND object_name(object_id) IS NOT NULL");
 
             var batches = new List<Batch>();
             


### PR DESCRIPTION
Fixes #25  .

Changes proposed in this pull request:
 - Exclude objects where object name is not null. (DDL Triggers) 

How to test this code:
 - Create a Database Trigger
 - Run tSQLt.RunAll when trigger is disabled. 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - Amazon RDS
 - Azure SQL DB
