### PR TITLE
Checking if the query for compatibility_level returns null on GetVersion

### DIFF
--- a/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCover/Gateway/DatabaseGateway.cs
@@ -32,7 +32,12 @@ namespace SQLCover.Gateway
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = query;
-                    return cmd.ExecuteScalar().ToString();
+
+                    var scalarResult = cmd.ExecuteScalar();
+
+                    if (scalarResult != null) return scalarResult.ToString();
+
+                    return null;
                 }
             }
         }


### PR DESCRIPTION
Fixes #32  .

Changes proposed in this pull request:
 - Check if the query `select compatibility_level from sys.databases where database_id = db_id();` returns null while checking version. In SQL Azure, it sometimes returns null, raising an exception.

How to test this code:
 - Run any new SQLCover session against an Azure SQL Database. Make sure that the query above returns nothing to validate the fix.

Has been tested on (remove any that don't apply):

 - Azure SQL DB
