### PR TITLE
Add LocalDbSqlTraceListener | add Cobertura report generation support

### DIFF
--- a/src/SQLCover/SQLCover/CoverageResult.cs
+++ b/src/SQLCover/SQLCover/CoverageResult.cs
@@ -53,7 +53,7 @@ namespace SQLCover
             CoveredStatementCount = _batches.Sum(p => p.CoveredStatementCount);
             StatementCount = _batches.Sum(p => p.StatementCount);
             HitCount = _batches.Sum(p => p.HitCount);
-            
+
 
         }
 
@@ -98,17 +98,17 @@ namespace SQLCover
                 "<table><thead><td>object name</td><td>statement count</td><td>covered statement count</td><td>coverage %</td></thead>");
 
             builder.AppendFormat("<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3:0.00}</td></tr>", "<b>Total</b>",
-                statements, coveredStatements, (float) coveredStatements / (float) statements * 100.0);
+                statements, coveredStatements, (float)coveredStatements / (float)statements * 100.0);
 
             foreach (
                 var batch in
                 _batches.Where(p => !p.ObjectName.Contains("tSQLt"))
-                    .OrderByDescending(p => (float) p.CoveredStatementCount / (float) p.StatementCount))
+                    .OrderByDescending(p => (float)p.CoveredStatementCount / (float)p.StatementCount))
             {
                 builder.AppendFormat(
                     "<tr><td><a href=\"#{0}\">{0}</a></td><td>{1}</td><td>{2}</td><td>{3:0.00}</td></tr>",
                     batch.ObjectName, batch.StatementCount, batch.CoveredStatementCount,
-                    (float) batch.CoveredStatementCount / (float) batch.StatementCount * 100.0);
+                    (float)batch.CoveredStatementCount / (float)batch.StatementCount * 100.0);
             }
 
             builder.Append("</table>");
@@ -154,20 +154,53 @@ namespace SQLCover
         /// http://cobertura.sourceforge.net/xml/coverage-03.dtd
         /// </summary>
         /// <returns></returns>
-        public string Cobertura()
+        public string Cobertura(string packageName = "sql", Func<Batch, string> getFilename = null)
         {
             var statements = _batches.Sum(p => p.StatementCount);
             var coveredStatements = _batches.Sum(p => p.CoveredStatementCount);
 
             var builder = new StringBuilder();
-            builder.Append("<?xml version=\"1.0\"?>");
-            builder.Append("<!--DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-03.dtd\"-->");
-            builder.AppendFormat("<coverage lines-valid=\"{0}\" lines-covered=\"{1}\" line-rate=\"{2}\" branch-rate=\"0.0\" version=\"1.9\" timestamp=\"{3}\">", statements, coveredStatements,coveredStatements / (float)statements, (DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds);
-            builder.Append("</coverage>\r\n");
+            builder.AppendLine(Unquote($@"<?xml version='1.0'?>
+<!--DOCTYPE coverage SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-03.dtd'-->
+<coverage lines-valid='{statements}' lines-covered='{coveredStatements}' line-rate='{coveredStatements / (float)statements}' version='1.9' timestamp='{(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds}'>
+ <packages>
+  <package name='{packageName}'>
+    <classes>"));
+
+            var fileMap = _batches.GroupBy(b => b.ObjectName, StringComparer.OrdinalIgnoreCase);
+            foreach (var file in fileMap)
+            {
+                var lines = file.Sum(b => b.StatementCount);
+                var coveredLines = file.Sum(b => b.CoveredStatementCount);
+                var anyBatch = file.First();
+                var objectName = anyBatch.ObjectName.ToLower();
+                var filename = getFilename?.Invoke(anyBatch) ?? anyBatch.FileName;
+                filename = filename.Replace(@"\", "/");
+
+                builder.AppendLine(Unquote($"    <class name='{objectName}' filename='{filename}' lines-valid='{lines}' lines-covered='{coveredLines}' line-rate='{coveredLines / (float)lines}' >"));
+                builder.AppendLine("     <methods/>");
+                builder.AppendLine("     <lines>");
+
+                foreach (var line in file.SelectMany(batch => batch.Statements))
+                {
+                    var offsetInfo = GetOffsets(line.Offset, line.Length, anyBatch.Text);
+                    builder.AppendLine(Unquote($"      <line number='{offsetInfo.StartLine}' hits='{line.HitCount}' branch='false' />"));
+                }
+
+                builder.AppendLine("     </lines>");
+                builder.AppendLine("    </class>");
+            }
+
+            builder.AppendLine(@"
+   </classes>
+  </package>
+ </packages>
+</coverage>");
 
             return builder.ToString();
-
         }
+
+        private static string Unquote(string quotedStr) => quotedStr.Replace("'", "\"");
 
         public string OpenCoverXml()
         {
@@ -179,7 +212,7 @@ namespace SQLCover
             builder.AppendFormat(
                 "<CoverageSession xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
                 "<Summary numSequencePoints=\"{0}\" visitedSequencePoints=\"{1}\" numBranchPoints=\"0\" visitedBranchPoints=\"0\" sequenceCoverage=\"{2}\" branchCoverage=\"0.0\" maxCyclomaticComplexity=\"0\" minCyclomaticComplexity=\"0\" /><Modules>\r\n"
-                , statements, coveredStatements, coveredStatements / (float) statements * 100.0);
+                , statements, coveredStatements, coveredStatements / (float)statements * 100.0);
 
             builder.Append("<Module hash=\"ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE-ED-DE\">");
             builder.AppendFormat("<FullName>{0}</FullName>", DatabaseName);
@@ -206,19 +239,19 @@ namespace SQLCover
                 builder.AppendFormat(
                     "<Class><Summary numSequencePoints=\"{0}\" visitedSequencePoints=\"{1}\" numBranchPoints=\"0\" visitedBranchPoints=\"0\" sequenceCoverage=\"{2}\" branchCoverage=\"0\" maxCyclomaticComplexity=\"0\" minCyclomaticComplexity=\"0\" /><FullName>{3}</FullName><Methods>"
                     , batch.Statements.Count, batch.CoveredStatementCount,
-                    (float) batch.CoveredStatementCount / (float) batch.StatementCount * 100.0
+                    (float)batch.CoveredStatementCount / (float)batch.StatementCount * 100.0
                     , batch.ObjectName);
 
 
                 builder.AppendFormat(
                     "\t\t<Method visited=\"{0}\" cyclomaticComplexity=\"0\" sequenceCoverage=\"{1}\" branchCoverage=\"0\" isConstructor=\"false\" isStatic=\"false\" isGetter=\"true\" isSetter=\"false\">\r\n",
                     batch.CoveredStatementCount > 0 ? "true" : "false",
-                    batch.CoveredStatementCount / (float) batch.StatementCount * 100.0);
+                    batch.CoveredStatementCount / (float)batch.StatementCount * 100.0);
 
                 builder.AppendFormat(
                     "\t\t<Summary numSequencePoints=\"{1}\" visitedSequencePoints=\"0\" numBranchPoints=\"0\" visitedBranchPoints=\"0\" sequenceCoverage=\"{2}\" branchCoverage=\"0\" maxCyclomaticComplexity=\"0\" minCyclomaticComplexity=\"0\" />\r\n",
                     batch.StatementCount, batch.CoveredStatementCount,
-                    batch.CoveredStatementCount / (float) batch.StatementCount * 100.0);
+                    batch.CoveredStatementCount / (float)batch.StatementCount * 100.0);
 
 
                 builder.AppendFormat(
@@ -259,6 +292,9 @@ namespace SQLCover
         }
 
         private OpenCoverOffsets GetOffsets(Statement statement, string text)
+            => GetOffsets(statement.Offset, statement.Length, text);
+
+        private OpenCoverOffsets GetOffsets(int offset, int length, string text)
         {
             var offsets = new OpenCoverOffsets();
 
@@ -276,13 +312,13 @@ namespace SQLCover
                         break;
                     default:
 
-                        if (index == statement.Offset)
+                        if (index == offset)
                         {
                             offsets.StartLine = line;
                             offsets.StartColumn = column;
                         }
 
-                        if (index == statement.Offset + statement.Length)
+                        if (index == offset + length)
                         {
                             offsets.EndLine = line;
                             offsets.EndColumn = column;

--- a/src/SQLCover/SQLCover/CoverageResult.cs
+++ b/src/SQLCover/SQLCover/CoverageResult.cs
@@ -5,8 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Security;
 using System.Text;
-using System.Windows.Forms;
-using System.Windows.Forms.VisualStyles;
 using SQLCover.Objects;
 using SQLCover.Parsers;
 

--- a/src/SQLCover/SQLCover/CoverageResult.cs
+++ b/src/SQLCover/SQLCover/CoverageResult.cs
@@ -163,7 +163,7 @@ namespace SQLCover
             builder.Append("<?xml version=\"1.0\"?>");
             builder.Append("<!--DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-03.dtd\"-->");
             builder.AppendFormat("<coverage lines-valid=\"{0}\" lines-covered=\"{1}\" line-rate=\"{2}\" branch-rate=\"0.0\" version=\"1.9\" timestamp=\"{3}\">", statements, coveredStatements,coveredStatements / (float)statements, (DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds);
-            builder.Append("<coverage>\r\n");
+            builder.Append("</coverage>\r\n");
 
             return builder.ToString();
 

--- a/src/SQLCover/SQLCover/SQLCover.csproj
+++ b/src/SQLCover/SQLCover/SQLCover.csproj
@@ -76,6 +76,7 @@
     <Compile Include="SqlCoverException.cs" />
     <Compile Include="StatementChecker.cs" />
     <Compile Include="Trace\AzureTraceController.cs" />
+    <Compile Include="Trace\SqlLocalDbTraceController.cs" />
     <Compile Include="Trace\SqlTraceController.cs" />
     <Compile Include="Trace\TraceController.cs" />
     <Compile Include="Trace\TraceControllerBuilder.cs" />

--- a/src/SQLCover/SQLCover/Trace/SqlLocalDbTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/SqlLocalDbTraceController.cs
@@ -1,0 +1,20 @@
+﻿using SQLCover.Gateway;
+using System.IO;
+
+namespace SQLCover.Trace
+{
+    class SqlLocalDbTraceController : SqlTraceController
+    {
+        public SqlLocalDbTraceController(DatabaseGateway gateway, string databaseName) : base(gateway, databaseName)
+        {
+        }
+
+        protected override void Create()
+        {
+            var logDir = Path.Combine(Path.GetTempPath(), nameof(SqlLocalDbTraceController));
+            if (!Directory.Exists(logDir)) { Directory.CreateDirectory(logDir); }
+
+            this.FileName = Path.Combine(logDir, Name);
+        }
+    }
+}

--- a/src/SQLCover/SQLCover/Trace/SqlLocalDbTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/SqlLocalDbTraceController.cs
@@ -15,6 +15,8 @@ namespace SQLCover.Trace
             if (!Directory.Exists(logDir)) { Directory.CreateDirectory(logDir); }
 
             this.FileName = Path.Combine(logDir, Name);
+
+            RunScript(CreateTrace, "Error creating the extended events trace, error: {0}");
         }
     }
 }

--- a/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
@@ -9,7 +9,7 @@ namespace SQLCover.Trace
     class SqlTraceController : TraceController
     {
         
-        private const string CreateTrace = @"CREATE EVENT SESSION [{0}] ON SERVER 
+        protected const string CreateTrace = @"CREATE EVENT SESSION [{0}] ON SERVER 
 ADD EVENT sqlserver.sp_statement_starting(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
 ADD TARGET package0.asynchronous_file_target(
      SET filename='{2}')

--- a/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
@@ -35,7 +35,7 @@ FROM sys.fn_xe_file_target_read_file(N'{0}*.xel', N'{0}*.xem', null, null);";
             
         }
 
-        private void Create()
+        protected virtual void Create()
         {
             var logDir = Gateway.GetRecords(GetLogDir).Rows[0].ItemArray[2].ToString();
             if (string.IsNullOrEmpty(logDir))

--- a/src/SQLCover/SQLCover/Trace/TraceControllerBuilder.cs
+++ b/src/SQLCover/SQLCover/Trace/TraceControllerBuilder.cs
@@ -16,6 +16,8 @@ namespace SQLCover.Trace
                     return new AzureTraceController(gateway, databaseName);
                 case TraceControllerType.Sql:
                     return new SqlTraceController(gateway, databaseName);
+                case TraceControllerType.SqlLocalDb:
+                    return new SqlLocalDbTraceController(gateway, databaseName);
             }
 
             var source = new DatabaseSourceGateway(gateway);
@@ -37,6 +39,7 @@ namespace SQLCover.Trace
         Default,
         Sql,
         Azure,
-        Exp
+        Exp,
+        SqlLocalDb
     }
 }


### PR DESCRIPTION
BugFix: xp_readerrorlog in SqlTraceController.Start() fails in SqlLocalDb
https://github.com/GoEddie/SQLCover/issues/42

Fixes # .
* Fix failure when running xp_readerrorlog on SqlServer. The method is just to fetch log location. Provide a default log location for SqlServer to dump logs/traces, in case this command fails. 

Changes proposed in this pull request:
 - as above. 

How to test this code:
 - Run SqlCover.Start() on SqlLocalDb that fails for xp_readerrorlog. 

Has been tested on (remove any that don't apply):
 - SQL Local Db 2019 (done)
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - Amazon RDS
 - Azure SQL DB
