### PR TITLE
Pass fileName as name when creating Batch objects

### DIFF
--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -64,7 +64,7 @@ public IEnumerable<Batch> GetBatches(List<string> objectFilter)
                 if (name != null && row["object_id"] as int? != null &&  DoesNotMatchFilter(name, objectFilter, excludedObjects))
                 {
                     batches.Add(
-                        new Batch(new StatementParser(version), quoted, EndDefinitionWithNewLine(GetDefinition(row)), null, name, (int) row["object_id"]));
+                        new Batch(new StatementParser(version), quoted, EndDefinitionWithNewLine(GetDefinition(row)), name, name, (int) row["object_id"]));
 
                 }
                 


### PR DESCRIPTION

Fixes # .

Changes proposed in this pull request:
 - Populate the Batch object with a FileName that matches the object name.
 - This allows the Cobertura method to correctly populate fileNames that match what SQLCover outputs.
 - 

How to test this code:
 -  Create a Cobertura coverage file and verify that filename is populated in the same format SaveSourceFiles uses.


Has been tested on (remove any that don't apply):
 - SQL Server 2016
