### PR TITLE
Add all coverable lines in the cobertura export

### DIFF
--- a/src/SQLCover/SQLCover/CoverageResult.cs
+++ b/src/SQLCover/SQLCover/CoverageResult.cs
@@ -343,7 +343,9 @@ namespace SQLCover
                 foreach (var line in file.SelectMany(batch => batch.Statements))
                 {
                     var offsetInfo = GetOffsets(line.Offset + coverageUpdateParam.OffsetCorrection, line.Length, anyBatch.Text, lineStart: 1 + coverageUpdateParam.LineCorrection);
-                    builder.AppendLine(Unquote($"      <line number='{offsetInfo.StartLine}' hits='{line.HitCount}' branch='false' />"));
+                    int lNum = offsetInfo.StartLine;
+                    while (lNum <= offsetInfo.EndLine)
+                        builder.AppendLine(Unquote($"      <line number='{lNum++}' hits='{line.HitCount}' branch='false' />"));
                 }
 
                 // gen file footer

--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -64,7 +64,7 @@ public IEnumerable<Batch> GetBatches(List<string> objectFilter)
                 if (name != null && row["object_id"] as int? != null &&  DoesNotMatchFilter(name, objectFilter, excludedObjects))
                 {
                     batches.Add(
-                        new Batch(new StatementParser(version), quoted, EndDefinitionWithNewLine(GetDefinition(row)), null, name, (int) row["object_id"]));
+                        new Batch(new StatementParser(version), quoted, EndDefinitionWithNewLine(GetDefinition(row)), name, name, (int) row["object_id"]));
 
                 }
                 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - Each coverable line in the cobertura file should be represented.  Currently only the first line of the SQL batch is represented.


How to test this code:
 - Create a cobertura output file and ensure line coverage extends into the batch.
 - 
 - 

Has been tested on (remove any that don't apply):
 - SQL Server 2016
![testResults](https://user-images.githubusercontent.com/5613297/73572231-81325d00-442d-11ea-9434-f47cbae965a1.png)
