### PR TITLE
Simplify the SQL trace data

### DIFF
--- a/src/SQLCover/SQLCover/CoverageResult.cs
+++ b/src/SQLCover/SQLCover/CoverageResult.cs
@@ -343,7 +343,9 @@ namespace SQLCover
                 foreach (var line in file.SelectMany(batch => batch.Statements))
                 {
                     var offsetInfo = GetOffsets(line.Offset + coverageUpdateParam.OffsetCorrection, line.Length, anyBatch.Text, lineStart: 1 + coverageUpdateParam.LineCorrection);
-                    builder.AppendLine(Unquote($"      <line number='{offsetInfo.StartLine}' hits='{line.HitCount}' branch='false' />"));
+                    int lNum = offsetInfo.StartLine;
+                    while (lNum <= offsetInfo.EndLine)
+                        builder.AppendLine(Unquote($"      <line number='{lNum++}' hits='{line.HitCount}' branch='false' />"));
                 }
 
                 // gen file footer

--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -64,7 +64,7 @@ public IEnumerable<Batch> GetBatches(List<string> objectFilter)
                 if (name != null && row["object_id"] as int? != null &&  DoesNotMatchFilter(name, objectFilter, excludedObjects))
                 {
                     batches.Add(
-                        new Batch(new StatementParser(version), quoted, EndDefinitionWithNewLine(GetDefinition(row)), null, name, (int) row["object_id"]));
+                        new Batch(new StatementParser(version), quoted, EndDefinitionWithNewLine(GetDefinition(row)), name, name, (int) row["object_id"]));
 
                 }
                 

--- a/src/SQLCover/SQLCover/Trace/AzureTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/AzureTraceController.cs
@@ -9,7 +9,7 @@ namespace SQLCover.Trace
     internal class AzureTraceController : TraceController
     {
         private const string CreateTrace = @"CREATE EVENT SESSION [{0}] ON DATABASE 
-ADD EVENT sqlserver.sp_statement_starting(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
+ADD EVENT sqlserver.sp_statement_starting( where ([sqlserver].[database_id]=({1})))
 add target package0.ring_buffer(set max_memory = 500
 ) /* not file {2}*/
 WITH (EVENT_RETENTION_MODE=ALLOW_MULTIPLE_EVENT_LOSS,MAX_DISPATCH_LATENCY=1 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF) 

--- a/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
@@ -10,7 +10,7 @@ namespace SQLCover.Trace
     {
         
         protected const string CreateTrace = @"CREATE EVENT SESSION [{0}] ON SERVER 
-ADD EVENT sqlserver.sp_statement_starting(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
+ADD EVENT sqlserver.sp_statement_starting( where ([sqlserver].[database_id]=({1})))
 ADD TARGET package0.asynchronous_file_target(
      SET filename='{2}')
 WITH (MAX_MEMORY=100 MB,EVENT_RETENTION_MODE=NO_EVENT_LOSS,MAX_DISPATCH_LATENCY=1 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF) 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
Removed tsql_stack and plan_handle from the trace.
The tsql_stack and to a lesser degree the plan_handle don't appear to be used.  They also cause the trace to be significantly larger.  In our database running 500 tests(we're just getting started too) results the trace file was over 1GB.  Removing these two fields drops down to 100MB.

DatabaseGateway.GetTraceRecords(...)  doesn't copy the tsql_stack or plan_handle data anywhere, EventsParser.Get2008StyleString does reference tsql_stack but the event xml does not contain this field since GetTraceRecords doesn't copy it.

How to test this code:
 - Run a trace over SQL cover session and verify coverage files
 - 
 - 

Has been tested on (remove any that don't apply):
 - SQL Server 2016

