### PR TITLE
Simplify SQL Trace Data

### DIFF
--- a/src/SQLCover/SQLCover/CodeCoverage.cs
+++ b/src/SQLCover/SQLCover/CodeCoverage.cs
@@ -20,6 +20,7 @@ namespace SQLCover
         private readonly List<string> _excludeFilter;
         private readonly bool _logging;
         private readonly SourceGateway _source;
+        private readonly string _sqlGrouping;
         private CoverageResult _result;
 
         public const short TIMEOUT_EXPIRED = -2; //From TdsEnums
@@ -45,7 +46,11 @@ namespace SQLCover
         {
         }
 
-        public CodeCoverage(string connectionString, string databaseName, string[] excludeFilter, bool logging, bool debugger, TraceControllerType traceType)
+        public CodeCoverage(string connectionString, string databaseName, string[] excludeFilter, bool logging, bool debugger, TraceControllerType traceType) : this(connectionString, databaseName, excludeFilter, logging, debugger, TraceControllerType.Default, "")
+        {
+        }
+
+        public CodeCoverage(string connectionString, string databaseName, string[] excludeFilter, bool logging, bool debugger, TraceControllerType traceType, string sqlGrouping)
         {
             if (debugger)
                 Debugger.Launch();
@@ -60,6 +65,7 @@ namespace SQLCover
             _traceType = traceType;
             _database = new DatabaseGateway(connectionString, databaseName);
             _source = new DatabaseSourceGateway(_database);
+            _sqlGrouping = sqlGrouping;
         }
 
         public bool Start(int timeOut = 30)
@@ -221,7 +227,8 @@ namespace SQLCover
         private void GenerateResults(List<string> filter, List<string> xml, List<string> sqlExceptions, string commandDetail)
         {
             var batches = _source.GetBatches(filter);
-            _result = new CoverageResult(batches, xml, _databaseName, _database.DataSource, sqlExceptions, commandDetail);
+            Dictionary<string, List<string>> sqlGrouping = _sqlGrouping == "" ? null : _source.GetSqlGrouping(_sqlGrouping);
+            _result = new CoverageResult(batches, xml, _databaseName, _database.DataSource, sqlExceptions, commandDetail, sqlGrouping);
         }
 
         public CoverageResult Results()

--- a/src/SQLCover/SQLCover/CoverageResult.cs
+++ b/src/SQLCover/SQLCover/CoverageResult.cs
@@ -343,7 +343,9 @@ namespace SQLCover
                 foreach (var line in file.SelectMany(batch => batch.Statements))
                 {
                     var offsetInfo = GetOffsets(line.Offset + coverageUpdateParam.OffsetCorrection, line.Length, anyBatch.Text, lineStart: 1 + coverageUpdateParam.LineCorrection);
-                    builder.AppendLine(Unquote($"      <line number='{offsetInfo.StartLine}' hits='{line.HitCount}' branch='false' />"));
+                    int lNum = offsetInfo.StartLine;
+                    while (lNum <= offsetInfo.EndLine)
+                        builder.AppendLine(Unquote($"      <line number='{lNum++}' hits='{line.HitCount}' branch='false' />"));
                 }
 
                 // gen file footer

--- a/src/SQLCover/SQLCover/Program.cs
+++ b/src/SQLCover/SQLCover/Program.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SQLCover
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            //CodeCoverage cover = new CodeCoverage("Server=localhost;Trusted_Connection=True", "MBITEST", new string[] { ".*MSins.*", ".*MSDel.*", ".*MSupd.*", ".*MSdel.*", ".*_AFT.*", ".*FLTR_AUDIT.*", ".*FLTR_ODS.*", ".*tr_MSTran_.*" }, false,false, 0, "SELECT team_name sql_group, '[dbo].[' + object_name + ']' object_name FROM dbo.TEAM_OWNERSHIP T1 INNER JOIN dbo.TEAM T on T1.team_key = T.team_key ");
+
+            //CodeCoverage cover = new CodeCoverage("Server=hcs-dev1-dbs1;Trusted_Connection=True", "MBITIME401", new string[] { ".*MSins.*", ".*MSDel.*", ".*MSupd.*", ".*MSdel.*", ".*_AFT.*", ".*FLTR_AUDIT.*", ".*FLTR_ODS.*", ".*tr_MSTran_.*" }, false, false, 0, " USE MBITEST; SELECT OBJECT_SCHEMA_NAME(sm.object_id) sql_group, ISNULL('[' + OBJECT_SCHEMA_NAME(sm.object_id) + '].[' + OBJECT_NAME(sm.object_id) + ']', '[' + st.name + ']')  object_name FROM sys.sql_modules sm LEFT JOIN sys.triggers st ON st.object_id = sm.object_id WHERE sm.object_id NOT IN(SELECT object_id FROM sys.objects WHERE type = 'IF') AND OBJECT_SCHEMA_NAME(sm.object_id)  is not null");
+            CodeCoverage cover = new CodeCoverage("Server=hcs-dev-dbs1;Trusted_Connection=True", "MBITEST", new string[] { ".*MSins.*", ".*MSDel.*", ".*MSupd.*", ".*MSdel.*", ".*_AFT.*", ".*FLTR_AUDIT.*", ".*FLTR_ODS.*", ".*tr_MSTran_.*" }, false, false, 0, "SELECT team_name sql_group, '[dbo].[' + object_name + ']' object_name FROM TEAM_OWNERSHIP T1 INNER JOIN TEAM T on T1.team_key = T.team_key ");
+
+            cover.Start();
+
+
+            cover.Stop();
+
+            File.WriteAllText(@"C:\Users\tgruetzmacher\OneDrive - Alegeus Technologies LLC\7.15\Unit Testing\CoverageResults\cobertura.xml", cover.Results().Cobertura());
+            cover.Results().SaveSourceFiles(@"C: \Users\tgruetzmacher\OneDrive - Alegeus Technologies LLC\7.15\Unit Testing\CoverageResults\sources");
+            //File.WriteAllText(@"C:\Users\tgruetzmacher\OneDrive - Alegeus Technologies LLC\7.15\Unit Testing\openCover.xml", cover.Results().OpenCoverXml());
+
+
+
+            return;
+        }
+
+    }
+}

--- a/src/SQLCover/SQLCover/SQLCover.csproj
+++ b/src/SQLCover/SQLCover/SQLCover.csproj
@@ -30,6 +30,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.150.4538.1\lib\net46\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
@@ -67,6 +70,7 @@
     <Compile Include="Parsers\EventsParser.cs" />
     <Compile Include="Gateway\DatabaseGateway.cs" />
     <Compile Include="Parsers\TSqlParserBuilder.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Parsers\StatementParser.cs" />
     <Compile Include="Source\DatabaseSourceGateway.cs" />

--- a/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/DatabaseSourceGateway.cs
@@ -64,7 +64,7 @@ public IEnumerable<Batch> GetBatches(List<string> objectFilter)
                 if (name != null && row["object_id"] as int? != null &&  DoesNotMatchFilter(name, objectFilter, excludedObjects))
                 {
                     batches.Add(
-                        new Batch(new StatementParser(version), quoted, EndDefinitionWithNewLine(GetDefinition(row)), null, name, (int) row["object_id"]));
+                        new Batch(new StatementParser(version), quoted, EndDefinitionWithNewLine(GetDefinition(row)), name, name, (int) row["object_id"]));
 
                 }
                 

--- a/src/SQLCover/SQLCover/Source/SourceGateway.cs
+++ b/src/SQLCover/SQLCover/Source/SourceGateway.cs
@@ -8,5 +8,6 @@ namespace SQLCover.Source
         SqlServerVersion GetVersion();
         IEnumerable<Batch> GetBatches(List<string> objectFilter);
         string GetWarnings();
+        Dictionary<string, List<string>> GetSqlGrouping(string sqlGrouping);
     }
 }

--- a/src/SQLCover/SQLCover/Trace/AzureTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/AzureTraceController.cs
@@ -9,7 +9,7 @@ namespace SQLCover.Trace
     internal class AzureTraceController : TraceController
     {
         private const string CreateTrace = @"CREATE EVENT SESSION [{0}] ON DATABASE 
-ADD EVENT sqlserver.sp_statement_starting(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
+ADD EVENT sqlserver.sp_statement_starting( where ([sqlserver].[database_id]=({1})))
 add target package0.ring_buffer(set max_memory = 500
 ) /* not file {2}*/
 WITH (EVENT_RETENTION_MODE=ALLOW_MULTIPLE_EVENT_LOSS,MAX_DISPATCH_LATENCY=1 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF) 

--- a/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
+++ b/src/SQLCover/SQLCover/Trace/SqlTraceController.cs
@@ -10,7 +10,7 @@ namespace SQLCover.Trace
     {
         
         protected const string CreateTrace = @"CREATE EVENT SESSION [{0}] ON SERVER 
-ADD EVENT sqlserver.sp_statement_starting(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
+ADD EVENT sqlserver.sp_statement_starting( where ([sqlserver].[database_id]=({1})))
 ADD TARGET package0.asynchronous_file_target(
      SET filename='{2}')
 WITH (MAX_MEMORY=100 MB,EVENT_RETENTION_MODE=NO_EVENT_LOSS,MAX_DISPATCH_LATENCY=1 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF) 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
Removed tsql_stack and plan_handle from the trace.
The tsql_stack and to a lesser degree the plan_handle don't appear to be used. They also cause the trace to be significantly larger. In our database running 500 tests(we're just getting started too) results the trace file was over 1GB. Removing these two fields drops down to 100MB.

DatabaseGateway.GetTraceRecords(...) doesn't copy the tsql_stack or plan_handle data anywhere, EventsParser.Get2008StyleString does reference tsql_stack but the event xml does not contain this field since GetTraceRecords doesn't copy it.

How to test this code:

Run a trace over SQL cover session and verify coverage files
Has been tested on (remove any that don't apply):

SQL Server 2016