### PR TITLE
github action using dotnet core

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -193,7 +193,7 @@ jobs:
     name: Snyk Security Scan
     steps:
       - uses: actions/checkout@v1
-      - name: Snyk CLI Action
-        uses: clarkio/snyk-cli-action@1.0.0
-        with: # Set the secret as an input
+        name: Snyk CLI Action
+      - uses: snyk/actions/node@master
+        env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -76,6 +76,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.401
+    - name: build dacpac
+        run: |
+          cd src/SQLCover/DatabaseProject.Build
+          dotnet build
     # - name: enabledb
     #   run: cp ./src/SQLCover/Data/appSettings.bitbucket.mssql.json ./src/SQLCover/Data/AppSettings.json
     # - name: install nbgv

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -93,18 +93,19 @@ jobs:
     needs: test
     # Service containers to run with `runner-job`
     services:
-      # Label used to access the service container
-      redis:
-        # Docker Hub image
+      sqlserver:
         image: mcr.microsoft.com/mssql/server:2019-latest
-        #
-        ports:
-          # Opens tcp port 6379 on the host and service container
-          - 1433:1433
         env:
-          GIT_SUBMODULE_STRATEGY: recursive
           ACCEPT_EULA: Y
-          SA_PASSWORD: yourStrong(!)Password
+          SA_PASSWORD: JdMsKZPBBA8kVFXVrj8d
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'JdMsKZPBBA8kVFXVrj8d' -Q 'SELECT 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 3s
+          --health-retries 10
+          --health-start-period 10s
     steps:
     # Download artifacts
     - name: download-artifact
@@ -127,7 +128,7 @@ jobs:
         /Properties:IncludeCompositeObjects=True
         /TargetServerName:localhost
         /TargetUser:sa
-        /TargetPassword:yourStrong(!)Password
+        /TargetPassword:JdMsKZPBBA8kVFXVrj8d
         /TargetDatabaseName:DatabaseProject
 
     # Dump logs of the container if something failed
@@ -162,7 +163,7 @@ jobs:
         dotnet-version: 3.1.401
     # Publish the project
     - name: publish project
-      run: dotnet publish ./test/TestProjectWithSDKRef/TestProjectWithSDKRef.csproj /p:TargetUser=sa /p:TargetPassword=JdMsKZPBBA8kVFXVrj8d /bl /p:DependencyVersion="1.*-*" /warnaserror:SQL71502
+      run: dotnet publish ./src/SQLCover/DatabaseProject.Build/DatabaseProject.Build.csproj /p:TargetUser=sa /p:TargetPassword=JdMsKZPBBA8kVFXVrj8d /bl /p:DependencyVersion="1.*-*" /warnaserror:SQL71502
 
     # Dump logs of the container if something failed
     - name: Dump docker logs on failure

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,0 +1,94 @@
+name: .NET Core
+
+on: [push]
+
+# use https://marketplace.visualstudio.com/items?itemName=me-dutour-mathieu.vscode-github-actions to validate yml in vscode
+env:
+  NUGET_PACKAGES_DIRECTORY: '.nupkg'
+  RESHARPER_CLI_NAME: 'JetBrains.ReSharper.CommandLineTools.Unix'
+  RESHARPER_CLI_VERSION: "2019.2.3"
+  DOCKER_DRIVER: overlay
+  CONTAINER_IMAGE: codeclimate/codeclimate
+  CONTAINER_TAG: '0.85.2'
+
+jobs:
+  # build:
+
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #   - uses: actions/checkout@v1
+  #   - name: Setup .NET Core
+  #     uses: actions/setup-dotnet@v1
+  #     with:
+  #       dotnet-version: 3.1.401
+  #   - name: Build with dotnet
+  #     run: dotnet build --configuration Release
+  #   - name: Tests
+  #     run: |
+  #       cp src/SQLCover/Data/appSettings.gitlab.json src/SQLCover/Data/AppSettings.json
+  #       dotnet test --logger "junit" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='./TestResults/'
+  #   - name: Coverage Report
+  #     run: |
+  #       dotnet --version
+  #       dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
+  #       ./tools/reportgenerator "-reports:**/TestResults/coverage.opencover.xml;" "-targetdir:Reports" -reportTypes:TextSummary;
+  #       ./tools/reportgenerator "-reports:**/TestResults/coverage.opencover.xml;" "-targetdir:Reports" -reportTypes:Html;
+  #       ./tools/reportgenerator "-reports:**/TestResults/coverage.opencover.xml;" "-targetdir:Reports" -reportTypes:Badges;
+  #       cat ./Reports/Summary.txt
+  #   - uses: actions/upload-artifact@v1
+  #     with:
+  #         name: CodeCoverage
+  #         path: Reports
+  #   - name: Resharper Code Quality
+  #     run: |
+  #       # apt update && apt install -y curl zip unzip
+  #       curl -LO "https://download.jetbrains.com/resharper/ReSharperUltimate.$RESHARPER_CLI_VERSION/$RESHARPER_CLI_NAME.$RESHARPER_CLI_VERSION.zip"
+  #       unzip -q $RESHARPER_CLI_NAME.$RESHARPER_CLI_VERSION.zip -d "resharper"
+  #       mkdir -p CodeQuality
+  #       files=(*.sln)
+  #       sh ./resharper/dupfinder.sh "${files[0]}" --output=CodeQuality/dupfinderReport.html --format=Html
+  #       sh ./resharper/inspectcode.sh "${files[0]}" --output=CodeQuality/inspectcodeReport.html --format=Html
+  #   - uses: actions/upload-artifact@v1
+  #     with:
+  #         name: CodeQuality
+  #         path: CodeQuality
+  
+  unit_test_db_mssql:
+    runs-on: ubuntu-latest
+    # Service containers to run with `runner-job`
+    services:
+      # Label used to access the service container
+      redis:
+        # Docker Hub image
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        #
+        ports:
+          # Opens tcp port 6379 on the host and service container
+          - 1433:1433
+        env:
+          GIT_SUBMODULE_STRATEGY: recursive
+          ACCEPT_EULA: Y
+          SA_PASSWORD: yourStrong(!)Password
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.401
+    # - name: enabledb
+    #   run: cp ./src/SQLCover/Data/appSettings.bitbucket.mssql.json ./src/SQLCover/Data/AppSettings.json
+    - name: Tests
+      run: |
+        cd src/SQLCover
+        dotnet test --logger "junit" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='./TestResults/'
+
+  security:
+    runs-on: ubuntu-latest
+    name: Snyk Security Scan
+    steps:
+      - uses: actions/checkout@v1
+      - name: Snyk CLI Action
+        uses: clarkio/snyk-cli-action@1.0.0
+        with: # Set the secret as an input
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -5,71 +5,12 @@ on: [push]
 # use https://marketplace.visualstudio.com/items?itemName=me-dutour-mathieu.vscode-github-actions to validate yml in vscode
 env:
   NUGET_PACKAGES_DIRECTORY: '.nupkg'
-  RESHARPER_CLI_NAME: 'JetBrains.ReSharper.CommandLineTools.Unix'
-  RESHARPER_CLI_VERSION: "2019.2.3"
   DOCKER_DRIVER: overlay
-  CONTAINER_IMAGE: codeclimate/codeclimate
-  CONTAINER_TAG: '0.85.2'
 
 jobs:
-  # build:
-
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   - name: Setup .NET Core
-  #     uses: actions/setup-dotnet@v1
-  #     with:
-  #       dotnet-version: 3.1.401
-  #   - name: Build with dotnet
-  #     run: dotnet build --configuration Release
-  #   - name: Tests
-  #     run: |
-  #       cp src/SQLCover/Data/appSettings.gitlab.json src/SQLCover/Data/AppSettings.json
-  #       dotnet test --logger "junit" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='./TestResults/'
-  #   - name: Coverage Report
-  #     run: |
-  #       dotnet --version
-  #       dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
-  #       ./tools/reportgenerator "-reports:**/TestResults/coverage.opencover.xml;" "-targetdir:Reports" -reportTypes:TextSummary;
-  #       ./tools/reportgenerator "-reports:**/TestResults/coverage.opencover.xml;" "-targetdir:Reports" -reportTypes:Html;
-  #       ./tools/reportgenerator "-reports:**/TestResults/coverage.opencover.xml;" "-targetdir:Reports" -reportTypes:Badges;
-  #       cat ./Reports/Summary.txt
-  #   - uses: actions/upload-artifact@v1
-  #     with:
-  #         name: CodeCoverage
-  #         path: Reports
-  #   - name: Resharper Code Quality
-  #     run: |
-  #       # apt update && apt install -y curl zip unzip
-  #       curl -LO "https://download.jetbrains.com/resharper/ReSharperUltimate.$RESHARPER_CLI_VERSION/$RESHARPER_CLI_NAME.$RESHARPER_CLI_VERSION.zip"
-  #       unzip -q $RESHARPER_CLI_NAME.$RESHARPER_CLI_VERSION.zip -d "resharper"
-  #       mkdir -p CodeQuality
-  #       files=(*.sln)
-  #       sh ./resharper/dupfinder.sh "${files[0]}" --output=CodeQuality/dupfinderReport.html --format=Html
-  #       sh ./resharper/inspectcode.sh "${files[0]}" --output=CodeQuality/inspectcodeReport.html --format=Html
-  #   - uses: actions/upload-artifact@v1
-  #     with:
-  #         name: CodeQuality
-  #         path: CodeQuality
   
   test:
     runs-on: ubuntu-latest
-    # Service containers to run with `runner-job`
-    # services:
-    #   # Label used to access the service container
-    #   redis:
-    #     # Docker Hub image
-    #     image: mcr.microsoft.com/mssql/server:2019-latest
-    #     #
-    #     ports:
-    #       # Opens tcp port 6379 on the host and service container
-    #       - 1433:1433
-    #     env:
-    #       GIT_SUBMODULE_STRATEGY: recursive
-    #       ACCEPT_EULA: Y
-    #       SA_PASSWORD: yourStrong(!)Password
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
@@ -170,30 +111,3 @@ jobs:
       if: failure()
       uses: jwalton/gh-docker-logs@v1
 
-
-    # - name: enabledb
-    #   run: cp ./src/SQLCover/Data/appSettings.bitbucket.mssql.json ./src/SQLCover/Data/AppSettings.json
-    # - name: install nbgv
-    #   run: dotnet tool install --tool-path . nbgv
-    # - name: set version
-    #   run: ./nbgv cloud -p ./src/SQLCover/DatabaseProject/DatabaseProject.sqlproj/ --all-vars
-    # # Run build for SDK package
-    # - name: dotnet build SDK
-    #   run: dotnet build ./src/SQLCover/DatabaseProject/DatabaseProject.sqlproj -c Release
-    # # Package SDK
-    # - name: dotnet pack SDK
-    #   run: dotnet pack -c Release src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj
-    # - name: Tests
-    #   run: |
-    #     cd src/SQLCover
-    #     dotnet test --logger "junit" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='./TestResults/'
-
-  security:
-    runs-on: ubuntu-latest
-    name: Snyk Security Scan
-    steps:
-      - uses: actions/checkout@v1
-        name: Snyk CLI Action
-      - uses: snyk/actions/node@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         dotnet-version: 3.1.401
     - name: build dacpac
-        run: |
+      run: |
           cd src/SQLCover/DatabaseProject.Build
           dotnet restore
           dotnet build --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -54,8 +54,43 @@ jobs:
   #         name: CodeQuality
   #         path: CodeQuality
   
-  unit_test_db_mssql:
+  test:
     runs-on: ubuntu-latest
+    # Service containers to run with `runner-job`
+    # services:
+    #   # Label used to access the service container
+    #   redis:
+    #     # Docker Hub image
+    #     image: mcr.microsoft.com/mssql/server:2019-latest
+    #     #
+    #     ports:
+    #       # Opens tcp port 6379 on the host and service container
+    #       - 1433:1433
+    #     env:
+    #       GIT_SUBMODULE_STRATEGY: recursive
+    #       ACCEPT_EULA: Y
+    #       SA_PASSWORD: yourStrong(!)Password
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.401
+    - name: build dacpac
+        run: |
+          cd src/SQLCover/DatabaseProject.Build
+          dotnet restore
+          dotnet build --configuration Release
+      # cd $GITHUB_WORKSPACE
+    # Upload dacpac
+    - name: upload
+      uses: actions/upload-artifact@v1
+      with:
+        name: dacpac-package
+        path: ./src/SQLCover/DatabaseProject.Build/bin/Release/netstandard2.0/
+  deploy-sqlpackage:
+    runs-on: ubuntu-latest
+    needs: test
     # Service containers to run with `runner-job`
     services:
       # Label used to access the service container
@@ -71,15 +106,70 @@ jobs:
           ACCEPT_EULA: Y
           SA_PASSWORD: yourStrong(!)Password
     steps:
+    # Download artifacts
+    - name: download-artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: dacpac-package
+        path: ~/dacpac-package
+    # Download sqlpackage
+    - name: download sqlpackage
+      run: >
+        curl -L https://go.microsoft.com/fwlink/?linkid=2113331 --output sqlpackage.zip &&
+        unzip sqlpackage.zip -d ~/sqlpackage &&
+        chmod a+x ~/sqlpackage/sqlpackage
+    # Run sqlpackage
+    - name: sqlpackage publish
+      run: >
+        ~/sqlpackage/sqlpackage
+        /Action:Publish
+        /SourceFile:~/dacpac-package/DatabaseProject.Build.dacpac
+        /Properties:IncludeCompositeObjects=True
+        /TargetServerName:localhost
+        /TargetUser:sa
+        /TargetPassword:yourStrong(!)Password
+        /TargetDatabaseName:DatabaseProject
+
+    # Dump logs of the container if something failed
+    - name: Dump docker logs on failure
+      if: failure()
+      uses: jwalton/gh-docker-logs@v1
+
+  # Attempt to deploy a project to a SQL Server instance running in a container using dotnet publish
+  deploy-publish:
+    runs-on: ubuntu-18.04
+    needs: test
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: JdMsKZPBBA8kVFXVrj8d
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'JdMsKZPBBA8kVFXVrj8d' -Q 'SELECT 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 3s
+          --health-retries 10
+          --health-start-period 10s
+    # Fetch sources
+    steps:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.401
-    - name: build dacpac
-        run: |
-          cd src/SQLCover/DatabaseProject.Build
-          dotnet build
+    # Publish the project
+    - name: publish project
+      run: dotnet publish ./test/TestProjectWithSDKRef/TestProjectWithSDKRef.csproj /p:TargetUser=sa /p:TargetPassword=JdMsKZPBBA8kVFXVrj8d /bl /p:DependencyVersion="1.*-*" /warnaserror:SQL71502
+
+    # Dump logs of the container if something failed
+    - name: Dump docker logs on failure
+      if: failure()
+      uses: jwalton/gh-docker-logs@v1
+
+
     # - name: enabledb
     #   run: cp ./src/SQLCover/Data/appSettings.bitbucket.mssql.json ./src/SQLCover/Data/AppSettings.json
     # - name: install nbgv

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -78,10 +78,20 @@ jobs:
         dotnet-version: 3.1.401
     # - name: enabledb
     #   run: cp ./src/SQLCover/Data/appSettings.bitbucket.mssql.json ./src/SQLCover/Data/AppSettings.json
-    - name: Tests
-      run: |
-        cd src/SQLCover
-        dotnet test --logger "junit" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='./TestResults/'
+    # - name: install nbgv
+    #   run: dotnet tool install --tool-path . nbgv
+    # - name: set version
+    #   run: ./nbgv cloud -p ./src/SQLCover/DatabaseProject/DatabaseProject.sqlproj/ --all-vars
+    # # Run build for SDK package
+    # - name: dotnet build SDK
+    #   run: dotnet build ./src/SQLCover/DatabaseProject/DatabaseProject.sqlproj -c Release
+    # # Package SDK
+    # - name: dotnet pack SDK
+    #   run: dotnet pack -c Release src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj
+    # - name: Tests
+    #   run: |
+    #     cd src/SQLCover
+    #     dotnet test --logger "junit" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='./TestResults/'
 
   security:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,4 @@ ModelManifest.xml
 *.jfm
 
 *.css
+.store

--- a/src/SQLCover/DatabaseProject.Build/DatabaseProject.Build.csproj
+++ b/src/SQLCover/DatabaseProject.Build/DatabaseProject.Build.csproj
@@ -2,9 +2,19 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <SqlServerVersion>Sql150</SqlServerVersion>
+
   </PropertyGroup>
+
+  <!-- <ItemGroup>
+    <SqlCmdVariable Include="DbReaderPassword" />
+  </ItemGroup> -->
 
   <ItemGroup>
     <Content Include="..\DatabaseProject\dbo\**\*.sql" />
   </ItemGroup>
+  <!-- https://github.com/rr-wfm/MSBuild.Sdk.SqlProj#pre-and-post-deployment-scripts -->
+  <!-- <ItemGroup>
+    <PostDeploy Include="..\Database\Post-Deployment\Script.PostDeployment.sql" />
+  </ItemGroup> -->
 </Project>

--- a/src/SQLCover/DatabaseProject.Build/DatabaseProject.Build.csproj
+++ b/src/SQLCover/DatabaseProject.Build/DatabaseProject.Build.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="MSBuild.Sdk.SqlProj/1.1.0">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="..\DatabaseProject\dbo\**\*.sql" />
+  </ItemGroup>
+</Project>

--- a/src/SQLCover/SQLCover.sln
+++ b/src/SQLCover/SQLCover.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestLib", "test\TestLib\Tes
 EndProject
 Project("{00D1A9C2-B5F0-4AF3-8072-F6C62B433612}") = "DatabaseWithTests", "test\DatabaseWithTests\DatabaseWithTests.sqlproj", "{021EDCB7-E7A1-4F6E-BF0D-73AA4DA7B62A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DatabaseProject.Build", "DatabaseProject.Build\DatabaseProject.Build.csproj", "{405DE3C4-9384-4289-99B3-40E2B5ED8A29}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{021EDCB7-E7A1-4F6E-BF0D-73AA4DA7B62A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{021EDCB7-E7A1-4F6E-BF0D-73AA4DA7B62A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{021EDCB7-E7A1-4F6E-BF0D-73AA4DA7B62A}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{405DE3C4-9384-4289-99B3-40E2B5ED8A29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{405DE3C4-9384-4289-99B3-40E2B5ED8A29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{405DE3C4-9384-4289-99B3-40E2B5ED8A29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{405DE3C4-9384-4289-99B3-40E2B5ED8A29}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes #57 

Changes proposed in this pull request:
 - dotnet core compliant project uses `<Project Sdk="MSBuild.Sdk.SqlProj/1.1.0">`
 - will now build dacpac on linux machine and can publish

How to test this code:
 - see github action `.github/workflows/dotnetcore.yml`
 - and running actions https://github.com/lastlink/SQLCover/actions

Has been tested on (remove any that don't apply):
- SQL Server 2019 (linux docker image)
