### PR TITLE
Support named pipe default tracing determine for SQL LocalDB datasource

### DIFF
--- a/src/SQLCover/SQLCoverLib/Trace/TraceControllerBuilder.cs
+++ b/src/SQLCover/SQLCoverLib/Trace/TraceControllerBuilder.cs
@@ -43,7 +43,8 @@ namespace SQLCover.Trace
 
         private bool LooksLikeLocalDb(string dataSource)
         {
-            return dataSource.ToLowerInvariant().Contains("(localdb)");
+            dataSource = dataSource.ToLowerInvariant();
+            return dataSource.Contains("(localdb)") || dataSource.StartsWith("np:\\\\.\\pipe\\localdb");
         }
     }
 


### PR DESCRIPTION
* for issue #67
* determine localdb when the datasource url starts with:
  'np:\\.\pipe\LOCALDB'

Fixes #67 .

Changes proposed in this pull request:
 - let datasource starts with 'np:\\.\pipe\LOCALDB' be localdb, when determine the actual default trace type.

How to test this code:
 - In our local build system. Apply the patch, and tests passed. 

Has been tested on (remove any that don't apply):

 - SQL LocalDB 2017

