### PR TITLE
Separate test launch from test coverage

### DIFF
--- a/src/SQLCover/SQLCoverLib/Trace/AzureTraceController.cs
+++ b/src/SQLCover/SQLCoverLib/Trace/AzureTraceController.cs
@@ -51,6 +51,10 @@ select  v.value('(/event/@timestamp)[1]', 'datetime'), v from a
         {
         }
 
+        public override void ComposeLogFileName()
+        {
+
+        }
 
         private void Create()
         {

--- a/src/SQLCover/SQLCoverLib/Trace/SqlTraceController.cs
+++ b/src/SQLCover/SQLCoverLib/Trace/SqlTraceController.cs
@@ -35,7 +35,12 @@ FROM sys.fn_xe_file_target_read_file(N'{0}*.xel', N'{0}*.xem', null, null);";
             
         }
 
-        protected virtual void Create()
+        public SqlTraceController(DatabaseGateway gateway, string databaseName, string name) : base(gateway, databaseName, name)
+        {
+
+        }
+
+        public override void ComposeLogFileName()
         {
             var logDir = Gateway.GetRecords(GetLogDir).Rows[0].ItemArray[2].ToString();
             if (string.IsNullOrEmpty(logDir))
@@ -45,7 +50,11 @@ FROM sys.fn_xe_file_target_read_file(N'{0}*.xel', N'{0}*.xem', null, null);";
 
             logDir = logDir.ToUpper().Replace("Logging SQL Server messages in file '".ToUpper(), "").Replace("'", "").Replace("ERRORLOG.", "").Replace("ERROR.LOG", "");
             FileName = Path.Combine(logDir, Name);
+        }
 
+        protected virtual void Create()
+        {
+            ComposeLogFileName();
             RunScript(CreateTrace, "Error creating the extended events trace, error: {0}");
         }
 

--- a/src/SQLCover/SQLCoverLib/Trace/TraceController.cs
+++ b/src/SQLCover/SQLCoverLib/Trace/TraceController.cs
@@ -19,6 +19,14 @@ namespace SQLCover.Trace
             Name = string.Format("SQLCover-Trace-{0}", Guid.NewGuid().ToString().Replace("{", "").Replace("}", "").Replace("-", ""));
         }
 
+        public TraceController(DatabaseGateway gateway, string databaseName, string name)
+        {
+            Gateway = gateway;
+            DatabaseId = gateway.GetString(string.Format("select db_id('{0}')", databaseName));
+            Name = string.Format("SQLCover-Trace-{0}", name);
+        }
+
+        public abstract void ComposeLogFileName();
         public abstract void Start();
         public abstract void Stop();
         public abstract List<string> ReadTrace();

--- a/src/SQLCover/SQLCoverLib/Trace/TraceControllerBuilder.cs
+++ b/src/SQLCover/SQLCoverLib/Trace/TraceControllerBuilder.cs
@@ -7,7 +7,7 @@ namespace SQLCover.Trace
 {
     class TraceControllerBuilder
     {
-        public TraceController GetTraceController(DatabaseGateway gateway, string databaseName, TraceControllerType type)
+        public TraceController GetTraceController(DatabaseGateway gateway, string databaseName, TraceControllerType type, string sessionName = null)
         {
 
          
@@ -16,7 +16,9 @@ namespace SQLCover.Trace
                 case TraceControllerType.Azure:
                     return new AzureTraceController(gateway, databaseName);
                 case TraceControllerType.Sql:
-                    return new SqlTraceController(gateway, databaseName);
+                    return string.IsNullOrWhiteSpace(sessionName)
+                        ? new SqlTraceController(gateway, databaseName)
+                        : new SqlTraceController(gateway, databaseName, sessionName);
                 case TraceControllerType.SqlLocalDb:
                     return new SqlLocalDbTraceController(gateway, databaseName);
             }
@@ -32,8 +34,10 @@ namespace SQLCover.Trace
             var isAzure = source.IsAzure();
 
             if(!isAzure)
-                return new SqlTraceController(gateway, databaseName);
-            
+                return string.IsNullOrWhiteSpace(sessionName)
+                    ? new SqlTraceController(gateway, databaseName)
+                    : new SqlTraceController(gateway, databaseName, sessionName);
+
             var version = source.GetVersion();
             if(version < SqlServerVersion.Sql120)
                 throw  new Exception("SQL Azure is only supported from Version 12");


### PR DESCRIPTION
Introduced two new options: **--mode** and **--sessionName**. Now it's possible to perform two _separate_ launches of the executable, with _the same_ session name provided - that's good if we want to run tests by some other means rather than by this executable via the --query option. For example:
```
SqlCoverCore.exe -m OnlyStart -s some_unique_id_1 -c Get-CoverTSql -e Export-OpenXml -k "Server=server_name_1;Trusted_Connection=True;" -d database_name_1
SqlCoverCore.exe -m OnlyStart -s some_unique_id_2 -c Get-CoverTSql -e Export-OpenXml -k "Server=server_name_2;Trusted_Connection=True;" -d database_name_2

(here you may run any tests from any tools at servers server_name_1 and server_name_2)

SqlCoverCore.exe -m OnlyStopAndReport -s some_unique_id_1 -c Get-CoverTSql -e Export-OpenXml -k "Server=server_name_1;Trusted_Connection=True;" -d database_name_1
SqlCoverCore.exe -m OnlyStopAndReport -s some_unique_id_2 -c Get-CoverTSql -e Export-OpenXml -k "Server=server_name_2;Trusted_Connection=True;" -d database_name_2
```

Changes proposed in this pull request:
 - described above

How to test this code:
 - described above (see after "For example:")

Has been tested on:
 - SQL Server 2017
