### PR TITLE
Upgraded to .net 5 and added new command GetCoverDotNetTest

### DIFF
--- a/src/SQLCover/SQLCoverLib/SQLCoverLib.csproj
+++ b/src/SQLCover/SQLCoverLib/SQLCoverLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SQLCover/SqlCoverCore.UnitTests/SqlCoverCore.UnitTests.csproj
+++ b/src/SQLCover/SqlCoverCore.UnitTests/SqlCoverCore.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/SQLCover/SqlCoverCore/Program.cs
+++ b/src/SQLCover/SqlCoverCore/Program.cs
@@ -34,7 +34,7 @@ namespace SQLCover.Core
             [Option('t', "exeName", Required = false, HelpText = "executable name")]
             public string ExeName { get; set; }
             [Option('m', "testDLLPath", Required = false, HelpText = "test dll path")]
-            public string TestPath { get; set; }
+            public string TestDLLPath { get; set; }
         }
 
         private enum CommandType
@@ -153,7 +153,7 @@ namespace SQLCover.Core
                                        coverage = new CodeCoverage(o.ConnectionString, o.databaseName);
                                        coverage.Start();
                                        var powerShell = PowerShell.Create();
-                                       powerShell.AddCommand("dotnet").AddArgument("test").AddArgument(o.TestPath);
+                                       powerShell.AddCommand("dotnet").AddArgument("test").AddArgument(o.TestDLLPath);
                                        powerShell.Invoke();
                                        results = coverage.Stop();
                                        break;
@@ -278,7 +278,7 @@ namespace SQLCover.Core
                         }
                         break;
                     case "testDLLPath":
-                        if (string.IsNullOrWhiteSpace(o.ExeName))
+                        if (string.IsNullOrWhiteSpace(o.TestDLLPath))
                         {
                             Console.WriteLine("testDLLPath" + requiredString);
                             valid = false;

--- a/src/SQLCover/SqlCoverCore/Program.cs
+++ b/src/SQLCover/SqlCoverCore/Program.cs
@@ -277,6 +277,13 @@ namespace SQLCover.Core
                             valid = false;
                         }
                         break;
+                    case "testDLLPath":
+                        if (string.IsNullOrWhiteSpace(o.ExeName))
+                        {
+                            Console.WriteLine("testDLLPath" + requiredString);
+                            valid = false;
+                        }
+                        break;
 
                     default:
                         Console.WriteLine("Required check on:" + param + " ignored");

--- a/src/SQLCover/SqlCoverCore/Program.cs
+++ b/src/SQLCover/SqlCoverCore/Program.cs
@@ -34,8 +34,12 @@ namespace SQLCover.Core
             [Option('t', "exeName", Required = false, HelpText = "executable name")]
             public string ExeName { get; set; }
         }
+
+        private CodeCoverage _codeCoverage;
+
         private enum CommandType
         {
+            StartCoverage,
             GetCoverTSql,
             GetCoverExe,
             GetCoverRedgateCITest,
@@ -72,6 +76,13 @@ namespace SQLCover.Core
                        string[] requiredExportParameters = null;
                        switch (o.Command)
                        {
+                           case "StartCoverage":
+                               cType = CommandType.StartCoverage;
+                               requiredParameters = new string[]{
+                                   "connectionString",
+                                   "databaseName"
+                               };
+                               break;
                            case "Get-CoverTSql":
                                cType = CommandType.GetCoverTSql;
                                requiredParameters = new string[]{
@@ -137,6 +148,13 @@ namespace SQLCover.Core
                                // run command
                                switch (cType)
                                {
+                                   case CommandType.StartCoverage:
+                                       coverage = new CodeCoverage(o.ConnectionString, o.databaseName);
+                                       coverage.Start();
+                                       Console.WriteLine("started");
+                                       if (Console.ReadLine() == "StopCoverage")
+                                           results = coverage.Stop();
+                                       break;
                                    case CommandType.GetCoverTSql:
                                        coverage = new CodeCoverage(o.ConnectionString, o.databaseName, null, true, o.Debug);
                                        results = coverage.Cover(o.Query);

--- a/src/SQLCover/SqlCoverCore/SqlCoverCore.csproj
+++ b/src/SQLCover/SqlCoverCore/SqlCoverCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>0.6.5</Version>
+    <Version>0.6.7</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>SQLCover</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/src/SQLCover/SqlCoverCore/SqlCoverCore.csproj
+++ b/src/SQLCover/SqlCoverCore/SqlCoverCore.csproj
@@ -1,15 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.6</Version>
+    <TargetFramework>net5.0</TargetFramework>
+    <Version>0.6.5</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>SQLCover</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cake.Powershell" Version="1.0.1" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
@@ -17,6 +19,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SQLCoverLib\SQLCoverLib.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="nupkg\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - Amazon RDS
 - Azure SQL DB
