### PR TITLE
Add timeout option -T for Get-CoverTsql

### DIFF
--- a/src/SQLCover/SqlCoverCore/Program.cs
+++ b/src/SQLCover/SqlCoverCore/Program.cs
@@ -33,6 +33,8 @@ namespace SQLCover.Core
             public string Args { get; set; }
             [Option('t', "exeName", Required = false, HelpText = "executable name")]
             public string ExeName { get; set; }
+            [Option('T', "timeout", Required = false, HelpText = "Timeout for Get-CoverTsql (in secs, default 30)")]
+            public int Timeout { get; set; }
         }
         private enum CommandType
         {
@@ -139,7 +141,7 @@ namespace SQLCover.Core
                                {
                                    case CommandType.GetCoverTSql:
                                        coverage = new CodeCoverage(o.ConnectionString, o.databaseName, null, true, o.Debug);
-                                       results = coverage.Cover(o.Query);
+                                       results = coverage.Cover(o.Query, o.Timeout);
                                        break;
                                    case CommandType.GetCoverExe:
                                        coverage = new CodeCoverage(o.ConnectionString, o.databaseName, null, true, o.Debug);


### PR DESCRIPTION
Timeout by default is 30 seconds but there wasn't any option to change it.
This PR adds a -T option usable with Get-CoverTsql

Has been tested on (remove any that don't apply):
 - SQL Server 2017 Docker image (mcr.microsoft.com/mssql/server:2017-latest)
