### PR TITLE
Filter out effectless statements

### DIFF
--- a/src/SQLCover/SQLCoverLib/CoverageResult.cs
+++ b/src/SQLCover/SQLCoverLib/CoverageResult.cs
@@ -43,7 +43,7 @@ namespace SQLCover
                 if (batch != null)
                 {
                     var item = batch.Statements.FirstOrDefault(p => _statementChecker.Overlaps(p, statement));
-                    if (item != null)
+                    if (item != null && (!item.HasRowCount || statement.RowCount > 0))
                     {
                         item.HitCount++;
                     }

--- a/src/SQLCover/SQLCoverLib/Gateway/DatabaseGateway.cs
+++ b/src/SQLCover/SQLCoverLib/Gateway/DatabaseGateway.cs
@@ -90,12 +90,14 @@ namespace SQLCover.Gateway
                             var objectId = xml.SelectNodes("/event/data[@name='object_id']").Item(0);
                             var offset = xml.SelectNodes("/event/data[@name='offset']").Item(0);
                             var offsetEnd = xml.SelectNodes("/event/data[@name='offset_end']").Item(0);
+                            var rowCount = xml.SelectNodes("/event/data[@name='row_count']").Item(0);
 
                             root.RemoveAll();
                                  
                             root.AppendChild(objectId);
                             root.AppendChild(offset);
                             root.AppendChild(offsetEnd);
+                            root.AppendChild(rowCount);
 
                             var row = ds.NewRow();
                             row["xml"] = root.OuterXml;

--- a/src/SQLCover/SQLCoverLib/Objects/CoveredStatement.cs
+++ b/src/SQLCover/SQLCoverLib/Objects/CoveredStatement.cs
@@ -5,5 +5,6 @@
         public int Offset;
         public int OffsetEnd;
         public int ObjectId;
+        public int RowCount;
     }
 }

--- a/src/SQLCover/SQLCoverLib/Objects/Statement.cs
+++ b/src/SQLCover/SQLCoverLib/Objects/Statement.cs
@@ -17,12 +17,13 @@ namespace SQLCover.Objects
 
     public class Statement : CoverageInformation
     {
-        public Statement(string text, int offset, int length, bool isCoverable)
+        public Statement(string text, int offset, int length, bool isCoverable, bool hasRowCount)
         {
             Text = text;
             Offset = offset;
             Length = length;
             IsCoverable = isCoverable;
+            HasRowCount = hasRowCount;
 
             NormalizeStatement();
         }
@@ -70,5 +71,6 @@ namespace SQLCover.Objects
         public int Length;
 
         public bool IsCoverable;
+        public bool HasRowCount;
     }
 }

--- a/src/SQLCover/SQLCoverLib/Parsers/EventsParser.cs
+++ b/src/SQLCover/SQLCoverLib/Parsers/EventsParser.cs
@@ -35,6 +35,7 @@ namespace SQLCover.Parsers
             statement.Offset = GetOffset();
             statement.OffsetEnd = GetOffsetEnd();
             statement.ObjectId = GetIntValue("object_id");
+            statement.RowCount = GetRowCount();
 
             if (_stringNumber < _xmlEvents.Count)
                 _doc = XDocument.Parse(_xmlEvents[_stringNumber++]);
@@ -65,6 +66,16 @@ namespace SQLCover.Parsers
 
             var offset = int.Parse(value);
             return offset;
+        }
+
+        private int GetRowCount()
+        {
+            var value = GetStringValue("row_count");
+            if (value == null)
+            {
+                value = Get2008StyleString("rowCount");
+            }
+            return int.Parse(value);
         }
 
         private string Get2008StyleString(string name)

--- a/src/SQLCover/SQLCoverLib/Parsers/StatementParser.cs
+++ b/src/SQLCover/SQLCoverLib/Parsers/StatementParser.cs
@@ -52,7 +52,7 @@ namespace SQLCover.Parsers
 
             if (ShouldNotEnumerateChildren(statement))
             {
-                Statements.Add(new Statement (_script.Substring(statement.StartOffset, statement.FragmentLength),  statement.StartOffset, statement.FragmentLength, false));
+                Statements.Add(new Statement (_script.Substring(statement.StartOffset, statement.FragmentLength),  statement.StartOffset, statement.FragmentLength, false, false));
                 _stopEnumerating = true;       //maybe ExplicitVisit would be simpler??
                 return;
             }
@@ -61,7 +61,7 @@ namespace SQLCover.Parsers
 
             if (!IsIgnoredType(statement))
             {
-                Statements.Add(new Statement (_script.Substring(statement.StartOffset, statement.FragmentLength), statement.StartOffset, statement.FragmentLength, CanBeCovered(statement)));
+                Statements.Add(new Statement (_script.Substring(statement.StartOffset, statement.FragmentLength), statement.StartOffset, statement.FragmentLength, CanBeCovered(statement), HasRowCount(statement)));
             }
 
             if (statement is IfStatement)
@@ -70,7 +70,7 @@ namespace SQLCover.Parsers
 
                 var offset = statement.StartOffset;
                 var length = ifStatement.Predicate.StartOffset + ifStatement.Predicate.FragmentLength - statement.StartOffset;
-                Statements.Add(new Statement (_script.Substring(offset, length), offset, length, CanBeCovered(statement)));
+                Statements.Add(new Statement (_script.Substring(offset, length), offset, length, CanBeCovered(statement), false));
             }
 
             if (statement is WhileStatement)
@@ -79,7 +79,7 @@ namespace SQLCover.Parsers
 
                 var offset = statement.StartOffset;
                 var length = whileStatement.Predicate.StartOffset + whileStatement.Predicate.FragmentLength - statement.StartOffset;
-                Statements.Add(new Statement (_script.Substring(offset, length), offset, length, CanBeCovered(statement)));
+                Statements.Add(new Statement (_script.Substring(offset, length), offset, length, CanBeCovered(statement), HasRowCount(statement)));
             }
         }
 
@@ -134,6 +134,20 @@ namespace SQLCover.Parsers
                 return false;
 
             return true;
+        }
+
+        private bool HasRowCount(TSqlStatement statement)
+        {
+            if (statement is SelectStatement)
+                return true;
+            if (statement is UpdateStatement)
+                return true;
+            if (statement is DeleteStatement)
+                return true;
+            if (statement is MergeStatement)
+                return true;
+
+            return false;
         }
     }
 }

--- a/src/SQLCover/SQLCoverLib/Trace/SqlTraceController.cs
+++ b/src/SQLCover/SQLCoverLib/Trace/SqlTraceController.cs
@@ -10,23 +10,19 @@ namespace SQLCover.Trace
     {
         
         protected const string CreateTrace = @"CREATE EVENT SESSION [{0}] ON SERVER 
-ADD EVENT sqlserver.sp_statement_starting(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
+ADD EVENT sqlserver.sp_statement_completed(action (sqlserver.plan_handle, sqlserver.tsql_stack) where ([sqlserver].[database_id]=({1})))
 ADD TARGET package0.asynchronous_file_target(
      SET filename='{2}')
 WITH (MAX_MEMORY=100 MB,EVENT_RETENTION_MODE=NO_EVENT_LOSS,MAX_DISPATCH_LATENCY=1 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF) 
 ";
 
-        private const string StartTraceFormat = @"alter event session [{0}] on server state = start
-";
+        private const string StartTraceFormat = @"alter event session [{0}] on server state = start";
 
-        private const string StopTraceFormat = @"alter event session [{0}] on server state = stop
-";
+        private const string StopTraceFormat = @"alter event session [{0}] on server state = stop";
 
         private const string DropTraceFormat = @"drop EVENT SESSION [{0}] ON SERVER ";
 
-        private const string ReadTraceFormat = @"select
-    event_data
-FROM sys.fn_xe_file_target_read_file(N'{0}*.xel', N'{0}*.xem', null, null);";
+        private const string ReadTraceFormat = @"select event_data FROM sys.fn_xe_file_target_read_file(N'{0}*.xel', N'{0}*.xem', null, null);";
 
         private const string GetLogDir = @"EXEC xp_readerrorlog 0, 1, N'Logging SQL Server messages in file'";
         


### PR DESCRIPTION
Filter out statement that do not modify any row while they should have. Rationale is these statements are not properly tested, most likely because the condition is false.


How to test this code:
```
create procedure test_cover as
begin
	create table #t (x int, y int)
	insert into #t values (1, 1)
	update #t set x = 0 where y = 0
	select * from #t
end
go
```

Update statement will be marked as not executed.

Has been tested on (remove any that don't apply):
 - SQL Server 2022 for Linux (Microsoft official Docker image)
