### PR TITLE
Mark declare statements with values as coverable

### DIFF
--- a/src/SQLCover/SQLCoverLib/Parsers/StatementParser.cs
+++ b/src/SQLCover/SQLCoverLib/Parsers/StatementParser.cs
@@ -125,7 +125,14 @@ namespace SQLCover.Parsers
                 return false;
 
             if (statement is DeclareVariableStatement)
+            {
+                DeclareVariableStatement declStatement = statement as DeclareVariableStatement;
+                foreach (DeclareVariableElement declStatementElem in declStatement.Declarations) {
+                    if (declStatementElem.Value != null)
+                        return true;
+                }
                 return false;
+            }
 
             if (statement is DeclareTableVariableStatement)
                 return false;


### PR DESCRIPTION
Mark declare statements SQL Server reports they are run.

How to test this code:
```
create or alter procedure test_cover as
begin
	declare @var int
		= 0
	declare @var1 int
		= (select 1 + 2)
	declare @var2 int
	declare @var3 int,
			@var4 int = 42,
			@var5 int
end
go
```

Has been tested on (remove any that don't apply):
 - SQL Server 2022 for Linux (Microsoft official Docker image)
