### PR TITLE
Print exception and exit with error code when they occur

### DIFF
--- a/src/SQLCover/SqlCoverCore/Program.cs
+++ b/src/SQLCover/SqlCoverCore/Program.cs
@@ -181,6 +181,14 @@ namespace SQLCover.Core
                                            resultString = results.OpenCoverXml();
                                            results.SaveResult(outputPath + "Coverage.opencover.xml", resultString);
                                            results.SaveSourceFiles(outputPath);
+                                           if (results.SqlExceptions.Count > 0)
+                                           {
+                                                foreach (var e in results.SqlExceptions)
+                                                {
+                                                    Console.WriteLine(e);
+                                                }
+                                                Environment.Exit(1);
+                                           }
                                            break;
                                        case CommandType.ExportHtml:
                                            resultString = results.Html();


### PR DESCRIPTION
Fix an issue where SQLCover silently ignored SQL exceptions with OpenCoverXML output.

How to test this code:
 - Create a code that would crash
 - Invoke this code with SQLCover
 - See exit code is not 0

Has been tested on (remove any that don't apply):
 - SQL Server 2022 docker image
 
